### PR TITLE
Fix wrong YouTube URL on About page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -83,7 +83,7 @@ export default function About() {
               In addition to coding, I also make{" "}
               <Link
                 className="underline"
-                href="https://www.youtube.com/channel/@brianruizy"
+                href="https://www.youtube.com/@brianruizy"
               >
                 YouTube
               </Link>{" "}


### PR DESCRIPTION
Hi. I discovered a small error with the YouTube link on the About page and fixed it.

![Screenshot 2024-03-25 at 21 21 30](https://github.com/BrianRuizy/b-r.io/assets/21696393/b3b387ff-3a06-4f5e-9668-0956106d0625)
